### PR TITLE
chore: refactor to use undo

### DIFF
--- a/MeetingNotes/Views/EditableAgendaItemListView.swift
+++ b/MeetingNotes/Views/EditableAgendaItemListView.swift
@@ -29,7 +29,6 @@ struct EditableAgendaItemListView: View {
         .focused($titleIsFocused)
         .onSubmit {
             agendaItemBinding.title.wrappedValue = agendaTitle
-            try! document.storeModelUpdates()
             // registering an undo with even an empty handler for re-do marks
             // the associated document as 'dirty' and causes SwiftUI to invoke
             // a snapshot to save the file.

--- a/MeetingNotes/Views/MeetingNoteDocumentView.swift
+++ b/MeetingNotes/Views/MeetingNoteDocumentView.swift
@@ -44,7 +44,6 @@ struct MeetingNoteDocumentView: View {
                             let newAgendaItem = AgendaItem(title: "")
                             print("Adding agenda item!")
                             document.model.agenda.append(newAgendaItem)
-                            try! document.storeModelUpdates()
                             undoManager?.registerUndo(withTarget: document) { _ in }
                             // registering an undo with even an empty handler for re-do marks
                             // the associated document as 'dirty' and causes SwiftUI to invoke


### PR DESCRIPTION
- undo triggers a snapshot, which encodes the latest document model implicitly