### PR TITLE
Move sync controller

### DIFF
--- a/MeetingNotes/MeetingNotesApp.swift
+++ b/MeetingNotes/MeetingNotesApp.swift
@@ -1,5 +1,7 @@
 import SwiftUI
 
+let sharedSyncCoordinator = DocumentSyncCoordinator()
+
 /// The document-based Meeting Notes application.
 @main
 struct MeetingNotesApp: App {

--- a/MeetingNotes/MeetingNotesDocument.swift
+++ b/MeetingNotes/MeetingNotesDocument.swift
@@ -64,7 +64,6 @@ final class MeetingNotesDocument: ReferenceFileDocument {
 
     static var readableContentTypes: [UTType] { [.meetingnote] }
 
-
     init() {
         Logger.document.debug("INITIALIZING NEW DOCUMENT")
         id = UUID()

--- a/MeetingNotes/MeetingNotesModel.swift
+++ b/MeetingNotes/MeetingNotesModel.swift
@@ -14,7 +14,7 @@ struct AgendaItem: Identifiable, Codable, Hashable {
         if let discussion {
             self.discussion = discussion
         } else {
-            self.discussion = AutomergeText("")
+            self.discussion = AutomergeText()
         }
     }
 }

--- a/MeetingNotes/PeerNetworking/SyncConnection.swift
+++ b/MeetingNotes/PeerNetworking/SyncConnection.swift
@@ -28,7 +28,7 @@ final class SyncConnection: ObservableObject {
 
     /// The document to which this connection is linked
     var documentId: UUID
-    
+
     var connection: NWConnection?
     /// A Boolean value that indicates this app initiated this connection.
 
@@ -57,7 +57,10 @@ final class SyncConnection: ObservableObject {
     ) {
         self.documentId = documentId
         syncState = SyncState()
-        let connection = NWConnection(to: endpoint, using: NWParameters.peerSyncParameters(documentId: documentId.uuidString))
+        let connection = NWConnection(
+            to: endpoint,
+            using: NWParameters.peerSyncParameters(documentId: documentId.uuidString)
+        )
         self.connection = connection
         self.endpoint = endpoint
         self.peerId = peerId

--- a/MeetingNotes/Views/AppTabView.swift
+++ b/MeetingNotes/Views/AppTabView.swift
@@ -68,7 +68,7 @@ struct AppTabView: View {
                 // upon choosing a new selection on macOS
                 .id(selection)
         }
-        .onAppear() {
+        .onAppear {
             // SwiftUI controls the lifecycle of MeetingNoteDocument instances,
             // including sometimes regenerating them when disk contents are updated
             // in the background, so register the current instance with the

--- a/MeetingNotes/Views/AppTabView.swift
+++ b/MeetingNotes/Views/AppTabView.swift
@@ -13,16 +13,10 @@ struct AppTabView: View {
         NavigationSplitView {
             VStack {
                 TextField("Meeting Title", text: $document.model.title)
-                    // Normally, I'd likely make this `.onSubmit`, but with
-                    // onChange, I can see live sync effects on each character update
-                    // in the text field.
-                    .onChange(of: document.model.title, perform: { _ in
+                    .onSubmit {
                         undoManager?.registerUndo(withTarget: document) { _ in }
-                        // Registering an undo with even an empty handler for re-do marks
-                        // the associated document as 'dirty' and causes SwiftUI to invoke
-                        // a snapshot to save the file.
                         updateDoc()
-                    })
+                    }
                     .autocorrectionDisabled()
                     .padding(.horizontal)
                 HStack {

--- a/MeetingNotes/Views/AppTabView.swift
+++ b/MeetingNotes/Views/AppTabView.swift
@@ -49,7 +49,7 @@ struct AppTabView: View {
                             }
                         }
                 }
-                PeerSyncView(syncController: document.syncController)
+                PeerSyncView(documentId: document.id, syncController: sharedSyncCoordinator)
             }
             .navigationSplitViewColumnWidth(min: 250, ideal: 250)
             .toolbar {
@@ -68,6 +68,13 @@ struct AppTabView: View {
                 // upon choosing a new selection on macOS
                 .id(selection)
         }
+        .onAppear() {
+            // SwiftUI controls the lifecycle of MeetingNoteDocument instances,
+            // including sometimes regenerating them when disk contents are updated
+            // in the background, so register the current instance with the
+            // sync coordinator as they become visible.
+            sharedSyncCoordinator.registerDocument(document)
+        }
         .onReceive(document.objectWillChange, perform: { _ in
             if !document.model.agendas.contains(where: { agendaItem in
                 agendaItem.id == selection
@@ -76,7 +83,7 @@ struct AppTabView: View {
             }
         })
         #if os(iOS)
-        // hides the additional navigation stacks that iOS imposes on a document-based app
+        // Hides the additional navigation stacks that iOS imposes on a document-based app
         .toolbar(.hidden, for: .navigationBar)
         #endif
     }

--- a/MeetingNotes/Views/NWBrowserResultItemView.swift
+++ b/MeetingNotes/Views/NWBrowserResultItemView.swift
@@ -26,7 +26,11 @@ struct NWBrowserResultItemView: View {
                 Text(nameFromResultMetadata())
                 Spacer()
                 Button {
-                    syncController.attemptToConnectToPeer(result.endpoint, forPeer: peerIdFromResultMetadata(), withDoc: documentId)
+                    syncController.attemptToConnectToPeer(
+                        result.endpoint,
+                        forPeer: peerIdFromResultMetadata(),
+                        withDoc: documentId
+                    )
                 } label: {
                     Text("Connect")
                 }

--- a/MeetingNotes/Views/NWBrowserResultItemView.swift
+++ b/MeetingNotes/Views/NWBrowserResultItemView.swift
@@ -2,6 +2,7 @@ import Network
 import SwiftUI
 
 struct NWBrowserResultItemView: View {
+    var documentId: UUID
     @ObservedObject var syncController: DocumentSyncCoordinator
     var result: NWBrowser.Result
 
@@ -25,7 +26,7 @@ struct NWBrowserResultItemView: View {
                 Text(nameFromResultMetadata())
                 Spacer()
                 Button {
-                    syncController.attemptToConnectToPeer(result.endpoint, forPeer: peerIdFromResultMetadata())
+                    syncController.attemptToConnectToPeer(result.endpoint, forPeer: peerIdFromResultMetadata(), withDoc: documentId)
                 } label: {
                     Text("Connect")
                 }

--- a/MeetingNotes/Views/PeerSyncView.swift
+++ b/MeetingNotes/Views/PeerSyncView.swift
@@ -2,17 +2,16 @@ import Network
 import SwiftUI
 
 struct PeerSyncView: View {
+    var documentId: UUID
     @ObservedObject var syncController: DocumentSyncCoordinator
 
     @State var browserActive: Bool = false
     @State var browserStyling: Color = .primary
 
     @State private var editNamePopoverShown: Bool = false
-    @AppStorage(MeetingNotesDefaultKeys.sharingIdentity) private var sharingIdentity: String = MeetingNotesDocument
-        .defaultSharingIdentity()
+    @AppStorage(MeetingNotesDefaultKeys.sharingIdentity) private var sharingIdentity: String = DocumentSyncCoordinator.defaultSharingIdentity()
 
     var body: some View {
-        let _ = Self._printChanges()
         VStack {
             HStack {
                 Text("Name: ")
@@ -57,7 +56,7 @@ struct PeerSyncView: View {
                 .padding(.leading)
                 LazyVStack {
                     ForEach(syncController.browserResults, id: \.hashValue) { result in
-                        NWBrowserResultItemView(syncController: syncController, result: result)
+                        NWBrowserResultItemView(documentId: documentId, syncController: syncController, result: result)
                             .padding(4)
                             .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 8))
                             .padding(.horizontal)
@@ -67,6 +66,7 @@ struct PeerSyncView: View {
             LazyVStack {
                 ForEach(syncController.connections) { connection in
                     SyncConnectionView(syncConnection: connection)
+                        .padding(.leading, 4)
                 }
             }
         }

--- a/MeetingNotes/Views/PeerSyncView.swift
+++ b/MeetingNotes/Views/PeerSyncView.swift
@@ -9,7 +9,8 @@ struct PeerSyncView: View {
     @State var browserStyling: Color = .primary
 
     @State private var editNamePopoverShown: Bool = false
-    @AppStorage(MeetingNotesDefaultKeys.sharingIdentity) private var sharingIdentity: String = DocumentSyncCoordinator.defaultSharingIdentity()
+    @AppStorage(MeetingNotesDefaultKeys.sharingIdentity) private var sharingIdentity: String = DocumentSyncCoordinator
+        .defaultSharingIdentity()
 
     var body: some View {
         VStack {

--- a/MeetingNotes/Views/SyncConnectionView.swift
+++ b/MeetingNotes/Views/SyncConnectionView.swift
@@ -7,52 +7,25 @@ struct SyncConnectionView: View {
     func stateRepresentationView() -> some View {
         switch syncConnection.connectionState {
         case .setup:
-            return Label {
-                Text("")
-            } icon: {
-                Image(systemName: "arrow.up.circle").foregroundColor(.gray)
-            }
-        case let .waiting(nWError):
-            return Label {
-                Text("waiting: \(nWError.localizedDescription)")
-            } icon: {
-                Image(systemName: "exclamationmark.triangle").foregroundColor(.yellow)
-            }
+            return Image(systemName: "arrow.up.circle").foregroundColor(.gray)
+        case .waiting(_):
+            return Image(systemName: "exclamationmark.triangle").foregroundColor(.yellow)
         case .preparing:
-            return Label {
-                Text("")
-            } icon: {
-                Image(systemName: "arrow.up.circle").foregroundColor(.yellow)
-            }
+            return Image(systemName: "arrow.up.circle").foregroundColor(.yellow)
         case .ready:
-            return Label {
-                Text("")
-            } icon: {
-                Image(systemName: "arrow.up.circle").foregroundColor(.blue)
-            }
-        case let .failed(nWError):
-            return Label {
-                Text("waiting: \(nWError.localizedDescription)")
-            } icon: {
-                Image(systemName: "x.square").foregroundColor(.red)
-            }
+            return Image(systemName: "arrow.up.circle").foregroundColor(.blue)
+        case .failed(_):
+            return Image(systemName: "x.square").foregroundColor(.red)
         case .cancelled:
-            return Label {
-                Text("")
-            } icon: {
-                Image(systemName: "x.square").foregroundColor(.gray)
-            }
+            return Image(systemName: "x.square").foregroundColor(.gray)
         default:
-            return Label {
-                Text("")
-            } icon: {
-                Image(systemName: "questionmark.square.dashed").foregroundColor(.primary)
-            }
+            return Image(systemName: "questionmark.square.dashed").foregroundColor(.primary)
         }
     }
 
     var body: some View {
         HStack(alignment: .firstTextBaseline) {
+            stateRepresentationView()
             if let txtRecord = syncConnection.endpoint?.txtRecord {
                 Text(txtRecord[TXTRecordKeys.name] ?? "unknown")
             } else {
@@ -60,7 +33,6 @@ struct SyncConnectionView: View {
             }
             Text(syncConnection.endpoint?.interface?.name ?? "")
             Spacer()
-            stateRepresentationView()
             Button {
                 syncConnection.cancel()
             } label: {

--- a/MeetingNotes/Views/SyncConnectionView.swift
+++ b/MeetingNotes/Views/SyncConnectionView.swift
@@ -8,13 +8,13 @@ struct SyncConnectionView: View {
         switch syncConnection.connectionState {
         case .setup:
             return Image(systemName: "arrow.up.circle").foregroundColor(.gray)
-        case .waiting(_):
+        case .waiting:
             return Image(systemName: "exclamationmark.triangle").foregroundColor(.yellow)
         case .preparing:
             return Image(systemName: "arrow.up.circle").foregroundColor(.yellow)
         case .ready:
             return Image(systemName: "arrow.up.circle").foregroundColor(.blue)
-        case .failed(_):
+        case .failed:
             return Image(systemName: "x.square").foregroundColor(.red)
         case .cancelled:
             return Image(systemName: "x.square").foregroundColor(.gray)

--- a/MeetingNotes/Views/SyncView.swift
+++ b/MeetingNotes/Views/SyncView.swift
@@ -9,9 +9,9 @@ struct SyncView: View {
             syncEnabledIndicator.toggle()
             if syncEnabledIndicator {
                 // only enable listening if an identity has been chosen
-                document.syncController.activate()
+                sharedSyncCoordinator.activate()
             } else {
-                document.syncController.deactivate()
+                sharedSyncCoordinator.deactivate()
             }
         } label: {
             Image(


### PR DESCRIPTION
Lessons learned (the hard way) - ReferenceFileDocument instances are ephemeral, and you shouldn't link too much crap to them. Moved the sync coordinator completely external in the app - I think it technically supports multiple documents open now and syncing, although only one of each documentId. Anyway - happier...