### PR TITLE
Fix: Handle empty _nameToDisplay_ on first run to enable P2P testing

### DIFF
--- a/MeetingNotes/Views/PeerSyncView.swift
+++ b/MeetingNotes/Views/PeerSyncView.swift
@@ -141,9 +141,10 @@ struct PeerSyncView: View {
             // first coming online and a default "???" value should be set whatever the inline default
             // from the library can provide. Since this is an @AppStorage() setup, if there's a configured
             // setting, this won't get hit and we're just waiting cycles with the check.
-            if nameToDisplay == "???" {
+            if nameToDisplay.isEmpty || nameToDisplay == "???" {
                 // no user default is setup, so load a default value from the library
                 nameToDisplay = await peerToPeer.peerName
+                editNamePopoverShown = true
             }
         }
     }


### PR DESCRIPTION
On first launch, _nameToDisplay_ resolves to "" instead of the expected “???”. This breaks the app’s flow, making P2P functionality untestable.

This patch adds a check for _.isEmpty_ and ensures _editNamePopoverShown_ opens when the value is empty. With this change, the app becomes usable out of the box for testing.

My guess is the library doesn't "load a default value" but rather just "". 
Not claiming this is the definitive fix, but it gets things working for now.

Pictured below is what the app looks like on first boot.
<img width="273" alt="image" src="https://github.com/user-attachments/assets/593f9688-5432-4df2-8707-2ac8228c815f" />

And here are the logs when you attempt to turn on the P2P functionality:

```
P2PNET: Updated bonjour network listener to advertise name
No peer name is set on the provider
```

